### PR TITLE
Update element control click options VC-2619

### DIFF
--- a/public/components/elementControls/controlAction.js
+++ b/public/components/elementControls/controlAction.js
@@ -53,10 +53,11 @@ export default function ControlAction (props) {
       workspaceContentState.set(false)
       workspaceStorage.trigger(event, id, tag, eventOptions)
     }
+    const isControlPermanent = event === 'add' && tag === 'column'
     layoutStorage.state('interactWithControls').set({
       type: 'controlClick',
       vcElementId: id,
-      vcControlIsPermanent: options.data.vcControlIsPermanent
+      vcControlIsPermanent: isControlPermanent
     })
   }
 

--- a/public/components/elementControls/controlAction.js
+++ b/public/components/elementControls/controlAction.js
@@ -50,7 +50,10 @@ export default function ControlAction (props) {
           eventOptions.elementTag = tag === 'layoutContentArea' ? 'layoutContentArea' : 'postsGridDataSourceArchive'
         }
       }
-      workspaceContentState.set(false)
+      const currentSettingsState = workspaceStorage.state('settings').get()
+      if (currentSettingsState?.action && event === currentSettingsState.action && tag !== 'column') {
+        workspaceContentState.set(false)
+      }
       workspaceStorage.trigger(event, id, tag, eventOptions)
     }
     const isControlPermanent = event === 'add' && tag === 'column'

--- a/public/components/elementControls/controlDropdownInner.js
+++ b/public/components/elementControls/controlDropdownInner.js
@@ -133,17 +133,15 @@ export default function ControlDropdownInner ({ elementId, isRightClick }) {
   }
 
   // edit design options control
-  if ((isRightClick && !options.isContainer) || options.isContainer) {
-    actions.push({
-      label: designOptionsText,
-      title: `${options.title} ${designOptionsText}`,
-      icon: 'vcv-ui-icon-brush-alt',
-      data: {
-        vcControlEvent: 'edit',
-        vcControlEventOptions: designOptionEvent
-      }
-    })
-  }
+  actions.push({
+    label: designOptionsText,
+    title: `${options.title} ${designOptionsText}`,
+    icon: 'vcv-ui-icon-brush-alt',
+    data: {
+      vcControlEvent: 'edit',
+      vcControlEventOptions: designOptionEvent
+    }
+  })
 
   // remove control
   actions.push({


### PR DESCRIPTION
The `options.data.vcControlIsPermanent` property is never used in the project. Replaced it with a condition.