### PR TITLE
VC-2731 Cover a special case for the "disable page title" setting

### DIFF
--- a/visualcomposer/Modules/Editors/Settings/TitleController.php
+++ b/visualcomposer/Modules/Editors/Settings/TitleController.php
@@ -33,9 +33,23 @@ class TitleController extends Container implements Module
             'titleRemove'
         );
 
-        //remove the filer before menu title render
+        /**
+         * Remove the filter before menu title render
+         *
+         * `the_title` filter also used for menu items. If we "disable the page title"
+         * it also will be removed from the menu (not menu item itself, only text).
+         *
+         * Special case: fallback_cb should be treated separately. By default, WordPress uses
+         * {@see \wp_page_menu()} as a fallback_cb, which triggers {@see \wp_list_pages()}.
+         *
+         * @see \wp_nav_menu()
+         */
         $this->wpAddFilter(
-            'wp_nav_menu_args',
+            'wp_nav_menu_objects',
+            'removeTitleFilter'
+        );
+        $this->wpAddFilter(
+            'wp_list_pages_excludes',
             'removeTitleFilter'
         );
 
@@ -44,6 +58,11 @@ class TitleController extends Container implements Module
             'wp_nav_menu_items',
             'addTitleFilter'
         );
+        $this->wpAddFilter(
+            'wp_list_pages',
+            'addTitleFilter'
+        );
+
         $this->addFilter('vcv:dataAjax:getData', 'outputTitle');
         $this->addFilter('vcv:dataAjax:setData', 'setPageTitle');
     }

--- a/visualcomposer/Modules/Editors/Settings/TitleController.php
+++ b/visualcomposer/Modules/Editors/Settings/TitleController.php
@@ -42,6 +42,7 @@ class TitleController extends Container implements Module
          * Special case: fallback_cb should be treated separately. By default, WordPress uses
          * {@see \wp_page_menu()} as a fallback_cb, which triggers {@see \wp_list_pages()}.
          *
+         *
          * @see \wp_nav_menu()
          */
         $this->wpAddFilter(


### PR DESCRIPTION
1. Changed hook for removing title from `wp_nav_menu_args` to `wp_nav_menu_objects`.
Decided to move the hook a little bit further, after the part related to `fallback_cb`. See the [wp_nav_menu](https://github.com/WordPress/WordPress/blob/58dfeaa86f3ee7468f2494de352c2ef13b324ae3/wp-includes/nav-menu-template.php#L57). This will not break the logic when the removed filter doesn't apply back.

2. Process the `fallback_cb` separately
WordPress uses [wp_page_menu](https://github.com/WordPress/WordPress/blob/58dfeaa86f3ee7468f2494de352c2ef13b324ae3/wp-includes/post-template.php#L1390) as a default value for `fallback_cb`, which uses the [wp_list_pages](https://github.com/WordPress/WordPress/blob/58dfeaa86f3ee7468f2494de352c2ef13b324ae3/wp-includes/post-template.php#L1267) under the hood. That's why I add two filters: `wp_list_pages_excludes` and `wp_list_pages` to prevent removing page title from menu items for themes that relies on `fallback_cb` argument.