### PR TITLE
VC-2810 Editor doesn't save the correct state

### DIFF
--- a/visualcomposer/Modules/Vendors/Gutenberg/DisableController.php
+++ b/visualcomposer/Modules/Vendors/Gutenberg/DisableController.php
@@ -86,13 +86,14 @@ class DisableController extends Container implements Module
             ($savedEditor === 'gutenberg' && $isEnabled)
             || $requestHelper->exists('classic-editor__forget')
             || (
-                $isEnabled && $requestHelper->input('vcv-set-editor') === 'gutenberg'
-                && !$requestHelper->exists(
-                    'classic-editor'
-                )
+                $isEnabled
+                && $requestHelper->input('vcv-set-editor') === 'gutenberg'
+                && !$requestHelper->exists('classic-editor')
             )
             || (
-                $isEnabled && !$requestHelper->exists('classic-editor')
+                $isEnabled
+                && $savedEditor !== 'classic'
+                && !$requestHelper->exists('classic-editor')
                 && !$gutenbergHelper->isVisualComposerPage($sourceId)
             )
         ) {
@@ -114,10 +115,13 @@ class DisableController extends Container implements Module
     protected function setEditor(Request $requestHelper)
     {
         if ($requestHelper->exists(VCV_PREFIX . 'set-editor')) {
-            /**
-             * @var \WP_Post $post
-             */
-            $post = get_post(get_the_ID());
+            $sourceId = get_the_ID();
+            if (!$sourceId) {
+                $sourceId = $requestHelper->input('post');
+            }
+
+            /** @var \WP_Post $post */
+            $post = get_post($sourceId);
             $editor = $requestHelper->input(VCV_PREFIX . 'set-editor');
             if ($post && $editor) {
                 update_post_meta($post->ID, VCV_PREFIX . 'be-editor', $editor);


### PR DESCRIPTION
Tested the following scenarios:

#### Case 1: Classic Editor

1. Disable Gutenberg in settings
2. Create a new post/page via classic editor
3. Save it. Expected behavior: after page reload (or editing this post again later) the classic editor should be loaded
4. Enable Gutenberg in settings
5. Go to edit the same post again. Expected behavior: edit post via the classic editor
6. Click "Gutenberg Editor" under the title. Expected behavior: edit via Gutenberg
7. Edit and save a post (to update savedEditor)
8. Reload page. Expected behavior: edit via Gutenberg

#### Case 2: Gutenberg Editor

1. Enable Gutenberg in Settings
2. Create a new post/page via Gutenberg editor
3. Save it
4. "Back to WordPress" and edit the same post again. Expected behavior: editing via the Gutenberg editor
5. Disable Gutenberg in settings
6. Edit the same post again. Expected behavior: edit via classic editor

#### Case 3: VCWB with Gutenberg disabled

1. Disable Gutenberg in settings
2. Add a new page/post with Visual Composer
3. Edit and publish it
4. "Back to WordPress" (expected behavior: blank page with "Classic Editor" button)

#### Case 4: VCWB with Gutenberg enabled

1. Enable Gutenberg in settings
2. Add a new page/post with Visual Composer
3. Edit and publish it
4. "Back to WordPress" (expected behavior: blank page with "Gutenberg Editor" button)